### PR TITLE
Create pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,24 @@
+{
+    "user": "Zeex",
+    "repo": "samp-plugin-crashdetect",
+    "include_path": "include",
+    "resources": [
+        {
+            "name": "^crashdetect-(.*)-linux.tar.gz$",
+            "platform": "linux",
+            "archive": true,
+            "includes": ["."],
+            "plugins": ["crashdetect-(.*)-linux/crashdetect.so"]
+        },
+        {
+            "name": "^crashdetect-(.*)-win32.zip$",
+            "platform": "windows",
+            "archive": true,
+            "includes": ["."],
+            "plugins": ["crashdetect-(.*)-win32/crashdetect.dll"]
+        }
+    ],
+    "runtime": {
+        "plugins": ["Zeex/samp-plugin-crashdetect"]
+    }
+}


### PR DESCRIPTION
Since [sampctl](https://github.com/Southclaws/sampctl) is getting to the point where it's production-ready, I'm encouraging people to start using it while developing libraries as it should make the process of testing and developing a lot smoother. It's designed so you don't need a `pawn.json`/`pawn.yaml` ("Pawn-Package Definition" file) in every repo, but having it there really helps with dependency management! These changes are purely additive and do not change your code or scripting style in any way, you don't need to use sampctl yourself but I encourage you to [give it a try](https://github.com/Southclaws/sampctl/wiki#installation)!

- added sampctl package files for version control, so a user could now simply run `sampctl package install Zeex/samp-plugin-crashdetect` to start using this library in their gamemode. Also defines `resources` section which allows servers to automatically download a specific version of the plugin binaries.