### PR TITLE
Control long_call_time options AND bug fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Available settings:
   complete, but are just slow (thus affecting overall server execution and
   sync).  Default value is `5000` (5 milliseconds).
 
+  Use `0` to disable this check.
+
 Building from source code
 -------------------------
 

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -40,8 +40,71 @@ native GetNativeBacktrace(string[], size = sizeof(string));
 forward OnRuntimeError(code, &bool:suppress);
 
 stock bool:IsCrashDetectPresent() {
+	// 0xFF is roughly flags, but some are mutually exclusive:
+	//
+	//   1 - Present (read only, write always 0).
+	//   2 - long_call_time checks enabled (write ignored when `server.cfg` has `long_call_time 0`).
+	//   4 - long_call_time reset (write only, read always 0).
+	//
 	#emit zero.pri
 	#emit lctrl 0xFF
+	#emit not
+	#emit not
 	#emit retn
 	return false;
 }
+
+stock SetCrashDetectLongCallTime(us_time) {
+	#emit load.s.pri us_time
+	#emit sctrl 0xFE
+}
+
+stock ResetCrashDetectLongCallTime() {
+	#emit const.pri 4
+	#emit sctrl 0xFF
+}
+
+stock DisableCrashDetectLongCall() {
+	#emit const.pri 0
+	#emit sctrl 0xFF
+}
+
+stock EnableCrashDetectLongCall() {
+	#emit const.pri 2
+	#emit sctrl 0xFF
+}
+
+stock bool:IsCrashDetectLongCallEnabled() {
+	#emit zero.pri
+	#emit lctrl 0xFF
+	#emit shr.c.pri 1
+	#emit retn
+	return false;
+}
+
+stock GetCrashDetectLongCallTime() {
+	#emit zero.pri
+	#emit lctrl 0xFE
+	#emit retn
+	return 0;
+}
+
+// `GetCrashDetectDefaultLongCallTime` is too long.
+stock GetCrashDetectDefaultTime() {
+	// store the current value
+	#emit zero.pri
+	#emit lctrl 0xFE
+	#emit move.alt
+	// reset to and read the default
+	#emit const.pri 4
+	#emit sctrl 0xFF
+	#emit zero.pri
+	#emit lctrl 0xFE
+	// put the current value back
+	#emit xchg
+	#emit sctrl 0xFE
+	#emit move.pri
+	#emit retn
+	return 0;
+}
+

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -56,13 +56,14 @@ stock bool:IsCrashDetectPresent() {
 }
 
 stock SetCrashDetectLongCallTime(us_time) {
+	// Setting this to `0` doesn't change the internal time, merely disables the check.
 	#emit load.s.pri us_time
 	#emit sctrl 0xFE
 }
 
 stock DisableCrashDetectLongCall() {
 	#emit const.pri 0
-	#emit sctrl 0xFF
+	#emit sctrl 0xFE
 }
 
 stock EnableCrashDetectLongCall() {

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -44,7 +44,8 @@ stock bool:IsCrashDetectPresent() {
 	//
 	//   1 - Present (read only, write always 0).
 	//   2 - long_call_time checks enabled (write ignored when `server.cfg` has `long_call_time 0`).
-	//   4 - long_call_time reset (write only, read always 0).
+	//   4 - long_call_time reset to default time (write only, read always 0).
+	//   8 - long_call_time restart check from now (write only, read always 0).
 	//
 	#emit zero.pri
 	#emit lctrl 0xFF
@@ -59,11 +60,6 @@ stock SetCrashDetectLongCallTime(us_time) {
 	#emit sctrl 0xFE
 }
 
-stock ResetCrashDetectLongCallTime() {
-	#emit const.pri 4
-	#emit sctrl 0xFF
-}
-
 stock DisableCrashDetectLongCall() {
 	#emit const.pri 0
 	#emit sctrl 0xFF
@@ -71,6 +67,16 @@ stock DisableCrashDetectLongCall() {
 
 stock EnableCrashDetectLongCall() {
 	#emit const.pri 2
+	#emit sctrl 0xFF
+}
+
+stock ResetCrashDetectLongCallTime() {
+	#emit const.pri 4
+	#emit sctrl 0xFF
+}
+
+stock RestartCrashDetectLongCall() {
+	#emit const.pri 8
 	#emit sctrl 0xFF
 }
 

--- a/src/amx/amx.c
+++ b/src/amx/amx.c
@@ -73,6 +73,8 @@
   #include <windows.h>
 #endif
 
+void SetLongCallTime(unsigned int time);
+unsigned int LongCallOption(int option);
 
 /* When one or more of the AMX_funcname macris are defined, we want
  * to compile only those functions. However, when none of these macros
@@ -3031,8 +3033,11 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       case 6:
         pri=(cell)((unsigned char *)cip - code);
         break;
+      case 0xFE:
+        pri=LongCallOption(0);
+        break;
       case 0xFF:
-        pri=1;
+        pri=1|(LongCallOption(2)<<1);
         break;
       } /* switch */
       break;
@@ -3055,6 +3060,24 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
         break;
       case 6:
         cip=(cell *)(code + (int)pri);
+        break;
+      case 0xFE:
+        /* set long_call_time */
+        if (pri)
+          SetLongCallTime((unsigned int)pri);
+        else
+          LongCallOption(4);
+        break;
+      case 0xFF:
+        if (pri&2)
+          /* enable long_call_time check */
+          LongCallOption(5);
+        if (pri&4)
+          /* reset long_call_time */
+          LongCallOption(6);
+        if (pri&8)
+          /* restart long_call_time check */
+          LongCallOption(3);
         break;
       } /* switch */
       break;

--- a/src/amx/amx.c
+++ b/src/amx/amx.c
@@ -75,6 +75,7 @@
 
 void SetLongCallTime(unsigned int time);
 unsigned int LongCallOption(int option);
+unsigned int Paused(AMX * amx);
 
 /* When one or more of the AMX_funcname macris are defined, we want
  * to compile only those functions. However, when none of these macros
@@ -1715,7 +1716,7 @@ int AMXAPI amx_SetExecErrorHandler(AMX *amx, AMX_EXEC_ERROR handler) {
      * fast "indirect threaded" interpreter.
      */
 
-#define NEXT(cip)       do { (amx)->cip=(cell)cip-(cell)code; goto **cip++; } while (0)
+#define NEXT(cip)       do { while (Paused(amx)) { } (amx)->cip=(cell)cip-(cell)code; goto **cip++; } while (0)
 
 int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
 {
@@ -2830,6 +2831,8 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
 #else
 
   for (;;) {
+    /* halt here while crashdetect dumps information about us */
+    while (Paused(amx)) {}
     amx->cip=(cell)((unsigned char *)cip-code);
     op=(OPCODE) *cip++;
     switch (op) {

--- a/src/amxcallstack.cpp
+++ b/src/amxcallstack.cpp
@@ -68,10 +68,6 @@ const AMXCall &AMXCallStack::Top() const {
 }
 
 void AMXCallStack::Push(AMXCall call) {
-  // We only care about the start time of the whole stack, not every call within in.
-  if (IsEmpty()) {
-    start_ = std::chrono::high_resolution_clock::now();
-  }
   call_stack_.push(call);
 }
 

--- a/src/amxcallstack.h
+++ b/src/amxcallstack.h
@@ -69,7 +69,8 @@ class AMXCallStack {
   AMXCall &Top();
   const AMXCall &Top() const;
 
-  time_point Start() const { return start_;   }
+  time_point Start() const { return start_; }
+  void Reset(time_point t) { start_ = t; }
 
   void Push(AMXCall call);
   AMXCall Pop();

--- a/src/amxcallstack.h
+++ b/src/amxcallstack.h
@@ -26,7 +26,6 @@
 #define AMXCALLSTACK_H
 
 #include <stack>
-#include <chrono>
 #include "amxref.h"
 
 class AMXCall {
@@ -62,22 +61,16 @@ class AMXCall {
 
 class AMXCallStack {
  public:
-  using time_point = std::chrono::high_resolution_clock::time_point;
-
   bool IsEmpty() const;
 
   AMXCall &Top();
   const AMXCall &Top() const;
-
-  time_point Start() const { return start_; }
-  void Reset(time_point t) { start_ = t; }
 
   void Push(AMXCall call);
   AMXCall Pop();
 
  private:
   std::stack<AMXCall> call_stack_;
-  time_point start_;
 };
 
 #endif // !AMXCALLSTACK_H

--- a/src/crashdetecthandler.cpp
+++ b/src/crashdetecthandler.cpp
@@ -102,7 +102,12 @@ void CrashDetectHandler::HangThread() {
   AMXCallStack::time_point last_warning = std::chrono::high_resolution_clock::now();
   AMXCallStack::time_point start;
   AMXCallStack::time_point cmp;
-  auto us = std::chrono::microseconds(Options::global_options().long_call_time());
+  unsigned int long_call_time = Options::global_options().long_call_time();
+  // disable the check by setting `long_call_time` to `0`.
+  if (long_call_time == 0) {
+    return;
+  }
+  auto us = std::chrono::microseconds(long_call_time);
   auto delay = us / 2;
   for ( ; running_; std::this_thread::sleep_for(delay)) {
     const std::lock_guard<std::mutex> lock(mutex_);

--- a/src/crashdetecthandler.cpp
+++ b/src/crashdetecthandler.cpp
@@ -106,15 +106,25 @@ void CrashDetectHandler::StopThread() {
   hang_thread_.join();
 }
 
-void CrashDetectHandler::SetLongCallTime(unsigned int time) {
-  long_call_time_current_ = std::chrono::microseconds(time);
-  if (time) {
-    long_call_time_delay_ = std::chrono::microseconds(time / 2);
+extern "C" {
+  unsigned int GetDefaultLongCallTime() {
+    return (unsigned int)CrashDetectHandler::long_call_time_original_.count();
   }
-}
 
-void CrashDetectHandler::ResetLongCall() {
-  call_stack_.Reset(std::chrono::high_resolution_clock::now());
+  unsigned int GetLongCallTime() {
+    return (unsigned int)CrashDetectHandler::long_call_time_current_.count();
+  }
+
+  void SetLongCallTime(unsigned int time) {
+    CrashDetectHandler::long_call_time_current_ = std::chrono::microseconds(time);
+    if (time) {
+      CrashDetectHandler::long_call_time_delay_ = std::chrono::microseconds(time / 2);
+    }
+  }
+
+  void ResetLongCall() {
+    CrashDetectHandler::call_stack_.Reset(std::chrono::high_resolution_clock::now());
+  }
 }
 
 void CrashDetectHandler::HangThread() {

--- a/src/crashdetecthandler.h
+++ b/src/crashdetecthandler.h
@@ -44,10 +44,8 @@ namespace os {
   class Context;
 }
 
-extern "C" unsigned int GetDefaultLongCallTime();
-extern "C" unsigned int GetLongCallTime();
 extern "C" void SetLongCallTime(unsigned int time);
-extern "C" void ResetLongCall();
+extern "C" unsigned int LongCallOption(int option);
 
 class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
  public:
@@ -104,7 +102,7 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
   bool block_exec_errors_;
 
  private:
-  static std::chrono::microseconds long_call_time_original_;
+  static unsigned int long_call_time_original_;
   static std::chrono::microseconds long_call_time_current_;
   static std::chrono::microseconds long_call_time_delay_;
 
@@ -114,10 +112,8 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
   static AMXCallStack call_stack_;
 
 public:
-  friend unsigned int ::GetDefaultLongCallTime();
-  friend unsigned int ::GetLongCallTime();
   friend void ::SetLongCallTime(unsigned int time);
-  friend void ::ResetLongCall();
+  friend unsigned int ::LongCallOption(int option);
 };
 
 #endif // !CRASHDETECTHANDLER_H

--- a/src/crashdetecthandler.h
+++ b/src/crashdetecthandler.h
@@ -46,6 +46,7 @@ namespace os {
 
 extern "C" void SetLongCallTime(unsigned int time);
 extern "C" unsigned int LongCallOption(int option);
+extern "C" unsigned int Paused(AMX * amx);
 
 class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
  public:
@@ -107,13 +108,15 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
   static std::chrono::microseconds long_call_time_delay_;
 
   static std::thread hang_thread_;
-  static std::atomic<bool> running_;
+  static std::atomic<int> running_;
+  static AMXRef top_amx_;
   static std::mutex mutex_;
   static AMXCallStack call_stack_;
 
 public:
   friend void ::SetLongCallTime(unsigned int time);
   friend unsigned int ::LongCallOption(int option);
+  friend unsigned int ::Paused(AMX * amx);
 };
 
 #endif // !CRASHDETECTHANDLER_H

--- a/src/crashdetecthandler.h
+++ b/src/crashdetecthandler.h
@@ -44,6 +44,11 @@ namespace os {
   class Context;
 }
 
+extern "C" unsigned int GetDefaultLongCallTime();
+extern "C" unsigned int GetLongCallTime();
+extern "C" void SetLongCallTime(unsigned int time);
+extern "C" void ResetLongCall();
+
 class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
  public:
   friend class AMXHandler<CrashDetectHandler>; // for accessing private ctor
@@ -109,10 +114,10 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
   static AMXCallStack call_stack_;
 
 public:
-  static unsigned int GetDefaultLongCallTime() { return (unsigned int)long_call_time_original_.count(); }
-  static unsigned int GetLongCallTime() { return (unsigned int)long_call_time_current_.count(); }
-  static void SetLongCallTime(unsigned int time);
-  static void ResetLongCall();
+  friend unsigned int ::GetDefaultLongCallTime();
+  friend unsigned int ::GetLongCallTime();
+  friend void ::SetLongCallTime(unsigned int time);
+  friend void ::ResetLongCall();
 };
 
 #endif // !CRASHDETECTHANDLER_H

--- a/src/crashdetecthandler.h
+++ b/src/crashdetecthandler.h
@@ -99,10 +99,20 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
   bool block_exec_errors_;
 
  private:
+  static std::chrono::microseconds long_call_time_original_;
+  static std::chrono::microseconds long_call_time_current_;
+  static std::chrono::microseconds long_call_time_delay_;
+
   static std::thread hang_thread_;
   static std::atomic<bool> running_;
   static std::mutex mutex_;
   static AMXCallStack call_stack_;
+
+public:
+  static unsigned int GetDefaultLongCallTime() { return (unsigned int)long_call_time_original_.count(); }
+  static unsigned int GetLongCallTime() { return (unsigned int)long_call_time_current_.count(); }
+  static void SetLongCallTime(unsigned int time);
+  static void ResetLongCall();
 };
 
 #endif // !CRASHDETECTHANDLER_H

--- a/src/crashdetecthandler.h
+++ b/src/crashdetecthandler.h
@@ -28,14 +28,12 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdio>
-#include <thread>
-#include <atomic>
+#include <chrono>
 #include "amxcallstack.h"
 #include "amxdebuginfo.h"
 #include "amxhandler.h"
 #include "amxref.h"
 #include "regexp.h"
-#include <mutex>
 
 class AMXPathFinder;
 class AMXStackFrame;
@@ -46,7 +44,7 @@ namespace os {
 
 extern "C" void SetLongCallTime(unsigned int time);
 extern "C" unsigned int LongCallOption(int option);
-extern "C" unsigned int Paused(AMX * amx);
+extern "C" void CheckLongCallTime(void);
 
 class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
  public:
@@ -89,7 +87,6 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
 
  private:
   CrashDetectHandler(AMX *amx);
-  static void HangThread();
 
  private:
   AMXRef amx_;
@@ -105,18 +102,15 @@ class CrashDetectHandler: public AMXHandler<CrashDetectHandler> {
  private:
   static unsigned int long_call_time_original_;
   static std::chrono::microseconds long_call_time_current_;
-  static std::chrono::microseconds long_call_time_delay_;
+  static std::chrono::high_resolution_clock::time_point long_call_time_next_;
 
-  static std::thread hang_thread_;
-  static std::atomic<int> running_;
-  static AMXRef top_amx_;
-  static std::mutex mutex_;
+  static bool running_;
   static AMXCallStack call_stack_;
 
 public:
   friend void ::SetLongCallTime(unsigned int time);
   friend unsigned int ::LongCallOption(int option);
-  friend unsigned int ::Paused(AMX * amx);
+  friend void ::CheckLongCallTime(void);
 };
 
 #endif // !CRASHDETECTHANDLER_H


### PR DESCRIPTION
# Original PR:

This introduces script-side control of the `long_call_time` errors (#76), for example if you know a function is slow and just want to suppress the warning entirely.  You can also reset the timing if, for example, you want to know which sub-call is slow in a function that may make lots of calls.

For example, I've just updated YSI:

https://github.com/pawn-lang/YSI-Includes/commit/011ca59b49c65f1d4ead38ca14f16aaa288a898e

During startup, the code generation is very slow, so this disables the warning for that case.

https://github.com/pawn-lang/YSI-Includes/commit/5d6ee138c0f2397fd66fe510d15a60545d82fb3a

During testing one test could be very slow while all the others are fast.  This will reset the timing check between every test so that you get a warning for each slow test, not just one warning that all the tests together are slow.

You can also totally disable the long call checks now with:

`long_call_time 0`

# New PR:

In the course of more testing, I found a major bug in the code as it was (even before these new features).  Printing the stack trace modifies `amx->stk` and `amx->frm`, which is normally not a problem because the stack traces are printed when the code crashes.  However, now I was printing traces on still running code.  Because `amx->stk` et.al. aren't always updated from the local copies in `amx_Exec`, this would sometimes clobber useful bits of the stack.

Sadly, this has meant that I've had to switch to the originally suggested method (sort of) of polling from inside `amx_Exec`.  To not slow things down too much it checks for a long time delay every 5000 instructions, not in a separate thread.  This ensures that we can back up the important registers and pause execution while the stack trace is printing.