### PR TITLE
Address naught write detection

### DIFF
--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -71,6 +71,24 @@ stock EnableCrashDetectAddr0() {
 	#emit sctrl 0xFD
 }
 
+stock bool:IsCrashDetectAddr0Enabled() {
+	// Is the check enabled?  0 if off or doesn't exist.
+	#emit const.pri 0
+	#emit lctrl 0xFD
+	#emit retn
+	return false;
+}
+
+stock bool:HasCrashDetectAddr0() {
+	// Is the check possible?
+	#emit const.pri 0xFFFFFFFF // -1
+	#emit lctrl 0xFD           // 0 or 1
+	#emit const.alt 0
+	#emit sgeq                 // >= 0
+	#emit retn
+	return false;
+}
+
 stock DisableCrashDetectLongCall() {
 	#emit const.pri 0
 	#emit sctrl 0xFE

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -46,6 +46,7 @@ stock bool:IsCrashDetectPresent() {
 	//   2 - long_call_time checks enabled (write ignored when `server.cfg` has `long_call_time 0`).
 	//   4 - long_call_time reset to default time (write only, read always 0).
 	//   8 - long_call_time restart check from now (write only, read always 0).
+	//   16 - Error with the crashdetect user data.
 	//
 	#emit zero.pri
 	#emit lctrl 0xFF

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -61,6 +61,16 @@ stock SetCrashDetectLongCallTime(us_time) {
 	#emit sctrl 0xFE
 }
 
+stock DisableCrashDetectAddr0() {
+	#emit const.pri 0
+	#emit sctrl 0xFD
+}
+
+stock EnableCrashDetectAddr0() {
+	#emit const.pri 1
+	#emit sctrl 0xFD
+}
+
 stock DisableCrashDetectLongCall() {
 	#emit const.pri 0
 	#emit sctrl 0xFE
@@ -84,7 +94,8 @@ stock RestartCrashDetectLongCall() {
 stock bool:IsCrashDetectLongCallEnabled() {
 	#emit zero.pri
 	#emit lctrl 0xFF
-	#emit shr.c.pri 1
+	#emit const.alt 1
+	#emit and
 	#emit retn
 	return false;
 }
@@ -92,6 +103,7 @@ stock bool:IsCrashDetectLongCallEnabled() {
 stock GetCrashDetectLongCallTime() {
 	#emit zero.pri
 	#emit lctrl 0xFE
+	#emit shr.c.pri 1
 	#emit retn
 	return 0;
 }

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -62,36 +62,6 @@ stock SetCrashDetectLongCallTime(us_time) {
 	#emit sctrl 0xFE
 }
 
-stock DisableCrashDetectAddr0() {
-	#emit const.pri 0
-	#emit sctrl 0xFD
-}
-
-stock EnableCrashDetectAddr0() {
-	#emit const.pri 1
-	#emit sctrl 0xFD
-}
-
-stock bool:IsCrashDetectAddr0Enabled() {
-	// Is the check enabled?  0 if off or doesn't exist.
-	#emit const.pri 0
-	#emit lctrl 0xFD
-	#emit const.alt 1
-	#emit and
-	#emit retn
-	return false;
-}
-
-stock bool:HasCrashDetectAddr0() {
-	// Is the check possible?
-	#emit const.pri 0xFFFFFFFF // -1
-	#emit lctrl 0xFD           // 0 or 1
-	#emit const.alt 0
-	#emit sgeq                 // >= 0
-	#emit retn
-	return false;
-}
-
 stock DisableCrashDetectLongCall() {
 	#emit const.pri 0
 	#emit sctrl 0xFE
@@ -146,5 +116,35 @@ stock GetCrashDetectDefaultTime() {
 	#emit move.pri
 	#emit retn
 	return 0;
+}
+
+stock DisableCrashDetectAddr0() {
+	#emit const.pri 0
+	#emit sctrl 0xFD
+}
+
+stock EnableCrashDetectAddr0() {
+	#emit const.pri 1
+	#emit sctrl 0xFD
+}
+
+stock bool:IsCrashDetectAddr0Enabled() {
+	// Is the check enabled?  0 if off or doesn't exist.
+	#emit const.pri 0
+	#emit lctrl 0xFD
+	#emit const.alt 1
+	#emit and
+	#emit retn
+	return false;
+}
+
+stock bool:HasCrashDetectAddr0() {
+	// Is the check possible?
+	#emit const.pri 0xFFFFFFFF // -1
+	#emit lctrl 0xFD           // 0 or 1
+	#emit const.alt 0
+	#emit sgeq                 // >= 0
+	#emit retn
+	return false;
 }
 

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -76,6 +76,8 @@ stock bool:IsCrashDetectAddr0Enabled() {
 	// Is the check enabled?  0 if off or doesn't exist.
 	#emit const.pri 0
 	#emit lctrl 0xFD
+	#emit const.alt 1
+	#emit and
 	#emit retn
 	return false;
 }

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -42,11 +42,14 @@ forward OnRuntimeError(code, &bool:suppress);
 stock bool:IsCrashDetectPresent() {
 	// 0xFF is roughly flags, but some are mutually exclusive:
 	//
-	//   1 - Present (read only, write always 0).
+	//   1 - Cashdetect present (read only, write always 0).
 	//   2 - long_call_time checks enabled (write ignored when `server.cfg` has `long_call_time 0`).
 	//   4 - long_call_time reset to default time (write only, read always 0).
 	//   8 - long_call_time restart check from now (write only, read always 0).
 	//   16 - Error with the crashdetect user data.
+	//   32 - long_call_time control bit.
+	//   64 - address_naught control bit.
+	//   128 - address_naught detection enabled.
 	//
 	#emit zero.pri
 	#emit lctrl 0xFF
@@ -62,53 +65,62 @@ stock SetCrashDetectLongCallTime(us_time) {
 	#emit sctrl 0xFE
 }
 
+stock GetCrashDetectLongCallTime() {
+	#emit zero.pri
+	#emit lctrl 0xFE
+	#emit retn
+	return 0;
+}
+
 stock DisableCrashDetectLongCall() {
-	#emit const.pri 0
-	#emit sctrl 0xFE
+	#emit const.pri 32
+	#emit sctrl 0xFF
 }
 
 stock EnableCrashDetectLongCall() {
-	#emit const.pri 2
+	#emit const.pri 34
 	#emit sctrl 0xFF
 }
 
 stock ResetCrashDetectLongCallTime() {
-	#emit const.pri 4
+	#emit const.pri 36
 	#emit sctrl 0xFF
 }
 
 stock RestartCrashDetectLongCall() {
-	#emit const.pri 8
+	#emit const.pri 40
 	#emit sctrl 0xFF
 }
 
 stock bool:IsCrashDetectLongCallEnabled() {
 	#emit zero.pri
 	#emit lctrl 0xFF
+	#emit shr.c.pri 1
 	#emit const.alt 1
 	#emit and
 	#emit retn
 	return false;
 }
 
-stock GetCrashDetectLongCallTime() {
+stock bool:HasCrashDetectLongCall() {
+	// Is the check possible?
 	#emit zero.pri
-	#emit lctrl 0xFE
-	#emit shr.c.pri 1
+	#emit lctrl 0xFF
+	#emit shr.c.pri 5
+	#emit const.alt 1
+	#emit and
 	#emit retn
-	return 0;
+	return false;
 }
 
 // `GetCrashDetectDefaultLongCallTime` is too long.
 stock GetCrashDetectDefaultTime() {
 	// store the current value
-	#emit zero.pri
 	#emit lctrl 0xFE
 	#emit move.alt
 	// reset to and read the default
-	#emit const.pri 4
+	#emit const.pri 36
 	#emit sctrl 0xFF
-	#emit zero.pri
 	#emit lctrl 0xFE
 	// put the current value back
 	#emit xchg
@@ -119,19 +131,20 @@ stock GetCrashDetectDefaultTime() {
 }
 
 stock DisableCrashDetectAddr0() {
-	#emit const.pri 0
-	#emit sctrl 0xFD
+	#emit const.pri 64
+	#emit sctrl 0xFF
 }
 
 stock EnableCrashDetectAddr0() {
-	#emit const.pri 1
-	#emit sctrl 0xFD
+	#emit const.pri 192
+	#emit sctrl 0xFF
 }
 
 stock bool:IsCrashDetectAddr0Enabled() {
 	// Is the check enabled?  0 if off or doesn't exist.
-	#emit const.pri 0
-	#emit lctrl 0xFD
+	#emit zero.pri
+	#emit lctrl 0xFF
+	#emit shr.c.pri 7
 	#emit const.alt 1
 	#emit and
 	#emit retn
@@ -140,10 +153,11 @@ stock bool:IsCrashDetectAddr0Enabled() {
 
 stock bool:HasCrashDetectAddr0() {
 	// Is the check possible?
-	#emit const.pri 0xFFFFFFFF // -1
-	#emit lctrl 0xFD           // 0 or 1
-	#emit const.alt 0
-	#emit sgeq                 // >= 0
+	#emit zero.pri
+	#emit lctrl 0xFF
+	#emit shr.c.pri 6
+	#emit const.alt 1
+	#emit and
 	#emit retn
 	return false;
 }

--- a/src/amx/amx.c
+++ b/src/amx/amx.c
@@ -2982,18 +2982,26 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       break;
     case OP_STOR_PRI:
       GETPARAM(offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=pri;
       break;
     case OP_STOR_ALT:
       GETPARAM(offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=alt;
       break;
     case OP_STOR_S_PRI:
       GETPARAM(offs);
+      if (frm+offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)frm+(int)offs)=pri;
       break;
     case OP_STOR_S_ALT:
       GETPARAM(offs);
+      if (frm+offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)frm+(int)offs)=alt;
       break;
     case OP_SREF_PRI:
@@ -3001,6 +3009,8 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       amx->stk=stk;
       GETPARAM(offs);
       offs=*(cell *)(data+(int)offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=pri;
       break;
     case OP_SREF_ALT:
@@ -3008,22 +3018,30 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       amx->stk = stk;
       GETPARAM(offs);
       offs=*(cell *)(data+(int)offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=alt;
       break;
     case OP_SREF_S_PRI:
       GETPARAM(offs);
       offs=*(cell *)(data+(int)frm+(int)offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=pri;
       break;
     case OP_SREF_S_ALT:
       GETPARAM(offs);
       offs=*(cell *)(data+(int)frm+(int)offs);
+      if (offs==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)offs)=alt;
       break;
     case OP_STOR_I:
       /* verify address */
       if (alt>=hea && alt<stk || (ucell)alt>=(ucell)amx->stp)
         ABORT(amx,AMX_ERR_MEMACCESS);
+      if (alt==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       *(cell *)(data+(int)alt)=pri;
       break;
     case OP_STRB_I:
@@ -3031,6 +3049,8 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       /* verify address */
       if (alt>=hea && alt<stk || (ucell)alt>=(ucell)amx->stp)
         ABORT(amx,AMX_ERR_MEMACCESS);
+      if (alt==0)
+        ABORT(amx,AMX_ERR_USERDATA);
       switch (offs) {
       case 1:
         *(data+(int)alt)=(unsigned char)pri;

--- a/src/amx/amx.c
+++ b/src/amx/amx.c
@@ -2112,7 +2112,7 @@ static const void * const amx_opcodelist[] = {
     case 0xFD:
       /* control address_naught */
       if (address_naught_ctl==NULL)
-        pri=0;
+        pri=-2;
       else
         pri=address_naught_ctl(amx,-1);
       break;
@@ -2124,7 +2124,7 @@ static const void * const amx_opcodelist[] = {
       break;
     case 0xFF:
       if (long_call_ctl==NULL)
-        pri=0;
+        pri=17;
       else
         pri=1|(long_call_ctl(amx,AMX_LCT_OPTION,AMX_LCT_OPTION_ACTIVE)<<1);
       break;
@@ -3170,7 +3170,7 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       case 0xFD:
         /* control address_naught */
         if (address_naught_ctl==NULL)
-          pri=0;
+          pri=-2;
         else
           pri=address_naught_ctl(amx,-1);
         break;
@@ -3182,7 +3182,7 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
         break;
       case 0xFF:
         if (long_call_ctl==NULL)
-          pri=0;
+          pri=17;
         else
           pri=1|(long_call_ctl(amx,AMX_LCT_OPTION,AMX_LCT_OPTION_ACTIVE)<<1);
         break;

--- a/src/amx/amx.h
+++ b/src/amx/amx.h
@@ -171,6 +171,7 @@ typedef int (AMXAPI *AMX_CALLBACK)(struct tagAMX *amx, cell index,
 typedef int (AMXAPI *AMX_DEBUG)(struct tagAMX *amx);
 typedef int (AMXAPI *AMX_EXEC_ERROR)(struct tagAMX *amx, int index, cell *retval, int error);
 typedef int (AMXAPI *AMX_LCT_CTL)(struct tagAMX *amx, int option, int value);
+typedef int (AMXAPI *AMX_ADDR_0_ERR)(struct tagAMX *amx);
 
 #if !defined _FAR
   #define _FAR
@@ -294,6 +295,7 @@ typedef struct tagAMX_HEADER {
 typedef struct tagAMX_EXT_HOOKS {
   AMX_EXEC_ERROR exec_error;
   AMX_LCT_CTL long_call_ctl;
+  AMX_ADDR_0_ERR address_naught_err;
 } PACKED AMX_EXT_HOOKS;
 
 #if PAWN_CELL_SIZE==16
@@ -333,6 +335,7 @@ enum {
   AMX_ERR_PARAMS,       /* parameter error */
   AMX_ERR_DOMAIN,       /* domain error, expression result does not fit in range */
   AMX_ERR_GENERAL,      /* general error (unknown or unspecific error) */
+  AMX_ERR_ADDRESS_0,    /* wrote to address naught with error enabled */
 };
 
 /*      AMX_FLAG_CHAR16   0x01     no longer used */

--- a/src/amx/amx.h
+++ b/src/amx/amx.h
@@ -171,7 +171,7 @@ typedef int (AMXAPI *AMX_CALLBACK)(struct tagAMX *amx, cell index,
 typedef int (AMXAPI *AMX_DEBUG)(struct tagAMX *amx);
 typedef int (AMXAPI *AMX_EXEC_ERROR)(struct tagAMX *amx, int index, cell *retval, int error);
 typedef int (AMXAPI *AMX_LCT_CTL)(struct tagAMX *amx, int option, int value);
-typedef cell * AMX_ADDR_0_ERR;
+typedef int (AMXAPI * AMX_ADDR_0_CTL)(struct tagAMX *amx, int option);
 
 #if !defined _FAR
   #define _FAR
@@ -295,7 +295,7 @@ typedef struct tagAMX_HEADER {
 typedef struct tagAMX_EXT_HOOKS {
   AMX_EXEC_ERROR exec_error;
   AMX_LCT_CTL long_call_ctl;
-  char address_naught_err;
+  AMX_ADDR_0_CTL address_naught_ctl;
 } PACKED AMX_EXT_HOOKS;
 
 #if PAWN_CELL_SIZE==16

--- a/src/amx/amx.h
+++ b/src/amx/amx.h
@@ -171,7 +171,7 @@ typedef int (AMXAPI *AMX_CALLBACK)(struct tagAMX *amx, cell index,
 typedef int (AMXAPI *AMX_DEBUG)(struct tagAMX *amx);
 typedef int (AMXAPI *AMX_EXEC_ERROR)(struct tagAMX *amx, int index, cell *retval, int error);
 typedef int (AMXAPI *AMX_LCT_CTL)(struct tagAMX *amx, int option, int value);
-typedef int (AMXAPI *AMX_ADDR_0_ERR)(struct tagAMX *amx);
+typedef cell * AMX_ADDR_0_ERR;
 
 #if !defined _FAR
   #define _FAR
@@ -295,7 +295,7 @@ typedef struct tagAMX_HEADER {
 typedef struct tagAMX_EXT_HOOKS {
   AMX_EXEC_ERROR exec_error;
   AMX_LCT_CTL long_call_ctl;
-  AMX_ADDR_0_ERR address_naught_err;
+  char address_naught_err;
 } PACKED AMX_EXT_HOOKS;
 
 #if PAWN_CELL_SIZE==16

--- a/src/amx/amxaux.c
+++ b/src/amx/amxaux.c
@@ -130,6 +130,7 @@ static char *messages[] = {
       /* AMX_ERR_PARAMS    */ "Parameter error",
       /* AMX_ERR_DOMAIN    */ "Domain error, expression result does not fit in range",
       /* AMX_ERR_GENERAL   */ "General error (unknown or unspecific error)",
+      /* AMX_ERR_ADDRESS_0 */ "Wrote to banned address naught",
     };
   if (errnum < 0 || errnum >= sizeof messages / sizeof messages[0])
     return "(unknown)";

--- a/src/crashdetect.cpp
+++ b/src/crashdetect.cpp
@@ -287,6 +287,20 @@ int CrashDetect::OnLongCallRequest(int option, int value) {
   return AMX_ERR_NONE;
 }
 
+int CrashDetect::OnAddressNaughtRequest(int option) {
+  switch (option) {
+    case -1:
+      return address_naught_;
+    case 0:
+      address_naught_ = false;
+      break;
+    case 1:
+      address_naught_ = true;
+      break;
+  }
+  return AMX_ERR_NONE;
+}
+
 // static
 void CrashDetect::OnCrash(const os::Context &context) {
   CrashDetect *instance = nullptr;

--- a/src/crashdetect.cpp
+++ b/src/crashdetect.cpp
@@ -84,7 +84,8 @@ CrashDetect::CrashDetect(AMX *amx)
     prev_debug_(nullptr),
     prev_callback_(nullptr),
     last_frame_(amx->stp),
-    block_exec_errors_(false)
+    block_exec_errors_(false),
+    address_naught_(false)
 {
 }
 

--- a/src/crashdetect.h
+++ b/src/crashdetect.h
@@ -53,6 +53,7 @@ class CrashDetect: public AMXHandler<CrashDetect> {
   int OnExec(cell *retval, int index);
   int OnExecError(int index, cell *retval, int error);
   int OnLongCallRequest(int option, int value);
+  int OnAddressNaughtRequest(int option);
 
  public:
   static void PluginLoad();
@@ -94,6 +95,7 @@ class CrashDetect: public AMXHandler<CrashDetect> {
   std::string amx_path_;
   std::string amx_name_;
   bool block_exec_errors_;
+  bool address_naught_;
 
  private:
   static AMXCallStack call_stack_;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -191,7 +191,8 @@ PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX *amx) {
 
   static AMX_EXT_HOOKS ext_hooks = {
     OnExecError,
-    OnLongCallRequest
+    OnLongCallRequest,
+    0
   };
   amx_SetExtHooks(amx, &ext_hooks);
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -114,6 +114,11 @@ int AMXAPI OnLongCallRequest(AMX *amx, int option, int value) {
   return handler->OnLongCallRequest(option, value);
 }
 
+int AMXAPI OnAddressNaughtRequest(AMX *amx, int option) {
+  CrashDetect *handler = CrashDetect::GetHandler(amx);
+  return handler->OnAddressNaughtRequest(option);
+}
+
 } // anonymous namespace
 
 PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports() {
@@ -192,7 +197,7 @@ PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX *amx) {
   static AMX_EXT_HOOKS ext_hooks = {
     OnExecError,
     OnLongCallRequest,
-    0
+    OnAddressNaughtRequest
   };
   amx_SetExtHooks(amx, &ext_hooks);
 

--- a/tests/address_naught.pwn
+++ b/tests/address_naught.pwn
@@ -1,0 +1,51 @@
+native printf(const string[], {Float, _}:...);
+
+#include <crashdetect>
+
+// Not located at address 0, even though it is first.
+new var = 6;
+
+// The anonymous automata is always address 0.
+Func() <state_a>
+{
+	printf("state_a");
+}
+
+Func() <state_b>
+{
+	printf("state_b");
+}
+
+Func() <>
+{
+	printf("fallback");
+}
+
+main()
+{
+	printf("Address 0 write detection.");
+	printf("Available: %d", HasCrashDetectAddr0());
+	DisableCrashDetectAddr0();
+	printf("Enabled: %d", IsCrashDetectAddr0Enabled());
+	EnableCrashDetectAddr0();
+	printf("Enabled: %d", IsCrashDetectAddr0Enabled());
+
+	// Test variable writing (shouldn't trigger).
+	printf("Var: %d", var);
+	DisableCrashDetectAddr0();
+	var = 7;
+	printf("Var: %d", var);
+	EnableCrashDetectAddr0();
+	var = 8;
+	printf("Var: %d", var);
+
+	// Test state writing (should trigger).
+	Func();
+	DisableCrashDetectAddr0();
+	state state_a;
+	Func();
+	EnableCrashDetectAddr0();
+	state state_b;
+	Func();
+}
+


### PR DESCRIPTION
Adds detection for writing to address 0 (not always an error) and flags to control it.:

```
# Address Naught

Often writing to address naught is a mistake, it indicates that some target address is unset,
especially in larger modes.  `address_naught` mode detects all writes to this address and gives a
new (to VM) error in that case - `AMX_ERR_ADDRESS_0`.  Note that this isn't always an error, it is a
valid address and real data can be stored there, so if this detection is enabled the mode must
ensure that nothing important will be written there (fixes.inc does this by defining and not using
the anonymous automata).

## Functions

There are several functions in the include to use these tests:

* `DisableCrashDetectAddr0();` - Disable address naught write detection in this mode.
* `EnableCrashDetectAddr0();` - Enable address naught write detection in this mode.
* `bool:IsCrashDetectAddr0Enabled();` - Is the error currently enabled?
* `bool:HasCrashDetectAddr0();` - Does the current version of crashdetect support this feature?
```

This also cleaned up some other register uses.