### PR TITLE
63 character function names.

### DIFF
--- a/src/amx/CMakeLists.txt
+++ b/src/amx/CMakeLists.txt
@@ -19,6 +19,7 @@ add_definitions(
   -DAMX_XXXUSERDATA
   -DAMX_ANSIONLY
   -DAMX_NODYNALOAD
+  -DsNAMEMAX=63
 )
 
 add_library(amx STATIC

--- a/src/amx/amx.h
+++ b/src/amx/amx.h
@@ -217,7 +217,9 @@ typedef struct tagAMX_NATIVE_INFO {
 
 #define AMX_USERNUM     4
 #define sEXPMAX         19      /* maximum name length for file version <= 6 */
-#define sNAMEMAX        31      /* maximum name length of symbol name */
+#ifndef sNAMEMAX
+  #define sNAMEMAX      31      /* maximum name length of symbol name */
+#endif
 
 typedef struct tagAMX_FUNCSTUB {
   ucell address         PACKED;


### PR DESCRIPTION
`sNAMEMAX` was increased to `63` in open.mp.  This bumps the value in crashdetect as well.  I believe this change should be backwards-compatible with SA:MP - shorter function names are still valid, but I haven't tested it.