### PR TITLE
Sync with recent changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "*"
+      - "*/*"
+      - "**"
+  pull_request:
+    branches:
+      - "*"
+      - "*/*"
+      - "**"
+
+jobs:
+  build-windows-release:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: true
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install CMake
+        uses: lukka/get-cmake@v.3.23.2
+
+      - name: Generate build files
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. -G "Visual Studio 16 2019" -A Win32
+          cmake --build . --config Release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: crashdetect-win-release
+          path: build/Release/crashdetect.dll
+
+  build-linux-release:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: true
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install packages
+        run: sudo apt-get install g++-multilib
+
+      - name: Install CMake
+        uses: lukka/get-cmake@v.3.23.2
+
+      - name: Generate build files
+        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32
+
+      - name: Build
+        run: |
+          cd build
+          cmake --build . --config Release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: crashdetect-linux-release
+          path: build/crashdetect.so

--- a/include/crashdetect.inc
+++ b/include/crashdetect.inc
@@ -27,15 +27,18 @@
 #endif
 #define CRASHDETECT_INC
 
-// Backwards compatibility; will be removed in the future.
-#define PrintAmxBacktrace PrintBacktrace
-#define GetAmxBacktrace GetBacktrace
-
 native PrintBacktrace();
 native PrintNativeBacktrace();
 
 native GetBacktrace(string[], size = sizeof(string));
 native GetNativeBacktrace(string[], size = sizeof(string));
+
+// Backwards compatibility; will be removed in the future.
+#pragma deprecated Use `PrintBacktrace`
+native PrintAmxBacktrace = PrintBacktrace;
+
+#pragma deprecated Use `GetBacktrace`
+native GetAmxBacktrace(string[], size = sizeof(string)) = GetBacktrace;
 
 forward OnRuntimeError(code, &bool:suppress);
 

--- a/src/amx/CMakeLists.txt
+++ b/src/amx/CMakeLists.txt
@@ -19,6 +19,7 @@ add_definitions(
   -DAMX_XXXUSERDATA
   -DAMX_ANSIONLY
   -DAMX_NODYNALOAD
+  -DsNAMEMAX=63
 )
 
 add_library(amx STATIC

--- a/src/amx/amx.h
+++ b/src/amx/amx.h
@@ -217,7 +217,9 @@ typedef struct tagAMX_NATIVE_INFO {
 
 #define AMX_USERNUM     4
 #define sEXPMAX         19      /* maximum name length for file version <= 6 */
-#define sNAMEMAX        31      /* maximum name length of symbol name */
+#ifndef sNAMEMAX
+  #define sNAMEMAX      31      /* maximum name length of symbol name */
+#endif
 
 typedef struct tagAMX_FUNCSTUB {
   ucell address         PACKED;

--- a/src/amxref.cpp
+++ b/src/amxref.cpp
@@ -160,11 +160,11 @@ const char *AMXRef::GetString(uint32_t offset) const {
 }
 
 cell AMXRef::GetStackSpaceLeft() const {
-  return GetStk() - GetHlw();
+  return GetStk() - GetHea();
 }
 
 bool AMXRef::CheckStack() const {
-  return GetStk() >= GetHlw() && GetStk() <= GetStp();
+  return GetStk() >= GetHea() && GetStk() <= GetStp();
 }
 
 void AMXRef::PushStack(cell value) {

--- a/src/amxstacktrace.cpp
+++ b/src/amxstacktrace.cpp
@@ -183,17 +183,20 @@ AMXStackTrace GetAMXStackTrace(AMXRef amx,
                                cell frm,
                                cell cip,
                                int max_depth) {
-  if (amx.CheckStack() && amx.GetStackSpaceLeft() >= 8) {
+  // Use a fake frame, hopefully without clobbering anything in silly code.
+  cell stk = amx.GetStk();
+  cell hlw = amx.GetHea();
+  if (amx.CheckStack() && amx.GetStackSpaceLeft() >= (2 * sizeof(cell))) {
+    amx.SetStk(hlw + (2 * sizeof(cell)));
     amx.PushStack(cip);
     amx.PushStack(frm);
-    amx.SetFrm(amx.GetStk());
+    amx.SetFrm(hlw);
   }
 
   AMXStackTrace trace(amx, amx.GetFrm(), max_depth);
 
   if (amx.CheckStack()) {
-    amx.PopStack();
-    amx.PopStack();
+    amx.SetStk(stk);
     amx.SetFrm(frm);
   }
 


### PR DESCRIPTION
I had a fork for a few fixes that have proven stable, this is just to merge them back to the main branch because the situation is confusing for absolutely everybody!

- 63 character max function names.  This doesn't affect code with shorter limits, since 63>31, but allows the plugin to work better on open.mp with its higher limits.
- Fix a problem with the stack being clobbered when displaying errors in some code.  This only happened when the code itself did weird illegal things with the stack, but it shouldn't cause the plugin to crash.
- Merged @AmyrAhmady's CI support.
- Reduced the frequency at which long call checks are done (to never in `-d0`), since they don't need to be precise to the instruction and it actually had a noticeable impact on performance.  I know performance isn't a primary concern here, but this is a free win.